### PR TITLE
Use base basetest instead of opensusebasetest

### DIFF
--- a/products/rockstor/main.pm
+++ b/products/rockstor/main.pm
@@ -1,3 +1,5 @@
+use strict;
+use warnings;
 use scheduler 'load_yaml_schedule';
 
 return 1 if load_yaml_schedule;

--- a/schedule/installation/installation.yaml
+++ b/schedule/installation/installation.yaml
@@ -4,4 +4,4 @@ description:    >
     Copied from openSUSE's: https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/tests/installation
 schedule:
     - installation/isosize
-    - installation/bootloader
+#    - installation/bootloader

--- a/tests/installation/isosize.pm
+++ b/tests/installation/isosize.pm
@@ -8,7 +8,8 @@
 # - Check if iso size is smaller than max defined size
 # Maintainer: Alberto Planas <aplanas@suse.com>
 
-use base "opensusebasetest";
+# use base "opensusebasetest";
+use base 'basetest';
 use strict;
 use warnings;
 use testapi;


### PR DESCRIPTION
This PR switches our base test to the base package's basetest rather than opensusebasetest to trim down our need to import all of opensuse libraries as we do not need all of them. We might in the future if/when we expand our tests complexity but let's start simple for now.