### PR TITLE
Switch from graphical KDE menu to using Krunner (#2).

### DIFF
--- a/lib/Utils/Kde.pm
+++ b/lib/Utils/Kde.pm
@@ -21,10 +21,13 @@ use base 'Exporter';
 use Exporter;
 use strict;
 use warnings;
-use testapi qw(send_key assert_screen);
+use testapi;
+use utils;
 
 our @EXPORT = qw(
   launch_krunner
+  launch_konsole
+  launch_firefox
 );
 
 =head1 Utils::Kde
@@ -42,8 +45,60 @@ Launch KRunner
 
 =cut
 sub launch_krunner {
-    send_key('alt-f2');
-    assert_screen('krunner_started');
+    my $timeout = @_;
+    $timeout //= 30;
+    my $hotkey = 'alt-f2';
+
+    send_key($hotkey);
+
+    mouse_hide(1);
+    if (!check_screen('krunner_started', $timeout)) {
+        record_info('workaround', "Krunner does not show up on $hotkey, retrying up to ten times (see bsc#978027)");
+        send_key 'esc';    # To avoid failing needle on missing 'alt' key - poo#20608
+        send_key_until_needlematch('krunner_started', $hotkey, 10, 10);
+    }
+    wait_still_screen(2);
+}
+
+
+=head2 launch_konsole
+
+    launch_konsole();
+
+Launch Konsole using Krunner
+
+=cut
+sub launch_konsole {
+    # Launch KRunner
+    launch_krunner();
+    # Start Konsole
+    type_string_slow('konsole');
+    send_key('ret');
+    assert_screen('konsole_launched', 60);
+}
+
+
+=head2 launch_firefox
+
+    launch_firefox();
+
+Open Firefox to the given C<url> if given.
+
+=cut
+sub launch_firefox {
+    my %args = @_;
+    print "URL is: $args{url}\n";
+    # Create firefox command
+    my $firefox_cmd = 'firefox';
+    if (defined($args{url})) {
+        $firefox_cmd = $firefox_cmd . ' ' . $args{url};
+    }
+    print "firefox_cmd: $firefox_cmd\n";
+
+    # Type it in
+    type_string_slow($firefox_cmd);
+    send_key('ret');
+
 }
 
 1;

--- a/tests/webui/browse_to_rockstor.pm
+++ b/tests/webui/browse_to_rockstor.pm
@@ -24,24 +24,18 @@ use base 'basetest';
 use warnings;
 use strict;
 use testapi;
-use Utils::Kde qw(launch_krunner);
+use Utils::Kde qw(launch_konsole launch_firefox);
 use lockapi;
 use mmapi;
-use utils;
 
 sub run {
     # Wait until the system has fully booted to desktop
     sleep(20);
     assert_screen('desktop_ready', 600);
 
-    # We could use the ctl-alt-t shortcut to open Konsole
-    # but this is somehow not working 100% of the time.
-    # Let's thus use the UI instead.
-    assert_and_click('kde_logo');
-    assert_and_click('konsole');
-    assert_screen('konsole_launched', 40);
-
-    # wait until the parent (Rockstor) is ready
+    # Start Konsole
+    launch_konsole();
+    # Wait until the parent (rockstorserver) is ready
     mutex_wait 'rockstor_ready';
 
     # Test network connection
@@ -51,12 +45,8 @@ sub run {
     sleep(5); # sleep for 5 sec to allow visual inspection if needed
     enter_cmd('exit');
 
-    # Launch KRunner
-    launch_krunner();
-
     # Start firefox and browse to rockstorserver
-    type_string_slow('firefox https://rockstorserver');
-    send_key('ret');
+    launch_firefox(url => 'https://rockstorserver');
     assert_and_click('security_exception');
     assert_and_click('click_advanced');
     # Navigate to the "Accept" button and press "Enter"

--- a/tests/webui/start_konsole_root.pm
+++ b/tests/webui/start_konsole_root.pm
@@ -21,18 +21,17 @@ use base 'basetest';
 use warnings;
 use strict;
 use testapi;
+use Utils::Kde qw(launch_krunner launch_konsole);
 
 sub run {
     # Wait until the system has fully booted to desktop
     assert_screen('desktop_ready', 600);
     sleep(10); # most likely unnecessary
 
-    # We could use the ctl-alt-t shortcut to open Konsole
-    # but this is somehow not working 100% of the time.
-    # Let's thus use the UI instead.
-    assert_and_click('kde_logo');
-    assert_and_click('konsole');
-    assert_screen('konsole_launched', 40);
+    # Start Konsole
+    launch_konsole();
+
+    # Login as root
     enter_cmd('su');
     sleep(1);
     type_string('rockytest');


### PR DESCRIPTION
Fixes #2 

Using the graphical menu was not reliable (not working 100% of the time). This commit switches to using Krunner to launch applications.
- Move krunner launching logic to helpers
- Include retries when launching Krunner as it does not work 100% of the time
- Create new helper to launch firefox using the launch_krunner() helper

Tested as working in a dev single-instance openQA.